### PR TITLE
Groups support

### DIFF
--- a/examples.f90
+++ b/examples.f90
@@ -1,13 +1,14 @@
 program example_mo_netcdf
 
   use mo_kind  , only : i4, sp, dp
-  use mo_netcdf, only: NcDataset, NcDimension, NcVariable
+  use mo_netcdf, only: NcDataset, NcDimension, NcVariable, NcGroup
 
   implicit none
   
   type(NcDataset)   :: nc
   type(NcDimension) :: dim1, dim2, dim3
   type(NcVariable)  :: var
+  type(NcGroup)     :: grp
 
   ! some data
   integer(i4), parameter :: nx=10, ny=20, ntime=8
@@ -19,22 +20,23 @@ program example_mo_netcdf
   ! args:
   !     filename
   !     mode ("w": write, "r": read-only, "a": read-write)
-  nc = NcDataset("test.nc", "w") 
+  nc = NcDataset("test.nc", "w")
+  call nc%setGroup('group',grp)
 
   ! create dimensions
   ! args:
   !     dimension name 
   !     dimension length (< 0 for an unlimited dimension)
-  dim1 = nc%setDimension("time", -1)
-  dim2 = nc%setDimension("y", ny)
-  dim3 = nc%setDimension("x", nx)
+  dim1 = grp%setDimension("time", -1)
+  dim2 = grp%setDimension("y", ny)
+  dim3 = grp%setDimension("x", nx)
 
   ! set a variable
   ! args:
   !     variable name
   !     data type (currently available: "i8", "i16", "i32", "f32", "f64")
   !     dimensions array
-  var = nc%setVariable("data", "i32", (/dim3, dim2, dim1/))
+  var = grp%setVariable("data", "i32", (/dim3, dim2, dim1/))
 
   ! define a fill value
   ! args:
@@ -68,6 +70,11 @@ program example_mo_netcdf
      call var%setData(data(:,:,1)+i,start=(/1,1,i/))
   end do
 
+  ! add a group attribute, attributes can be set to any of the data structures
+  ! args:
+  !    name
+  !    any of the supported datatypes
+  call grp%setAttribute("auxiliar author", "Ricardo Torres")
   ! add a global attribute
   ! args:
   !    name


### PR DESCRIPTION
Hello,

I've altered this module a good bit. I've added the support for groups, but for that I had to create the NcAttribute and extend all types from there. The ncDataset was changed to extend the groups, since by definition it is the / group. 
Now we can set and get attributes form a group, variable or dimension with the same function. 

I've extended your examples with some of my changes and tested them. Worked in Ubuntu 14.04 and 16.04.
Sorry for having deleted yours comments and documentation, but it really was making my work difficult. Can you revert that with the merge? 

This was some work and I may even end not using it in my work (it is a lot slower to read or write than the HDF5 routines that to do the same thing...), but since it is done I hope you find it useful and are willing to merge it.

This was the first time I've done any code with a object orientated approach. Learned a lot, thank you!
This is also my first time in git, so if i'm doing things wrong please let me know.
I'm open for any questions or doubts.

Best regards,
Ricardo Torres 
 